### PR TITLE
Various fixes based on 1925 London edition

### DIFF
--- a/se-lint-ignore.xml
+++ b/se-lint-ignore.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<se-lint-ignore>
+	<file path="act-4.xhtml">
+		<ignore code="t-041">
+			<line>176</line>
+			<reason>Punctuation used as dialogue.</reason>
+		</ignore>
+	</file>
+</se-lint-ignore>

--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -56,7 +56,7 @@
 		<dc:language>en-GB</dc:language>
 		<dc:source>https://www.gutenberg.org/ebooks/3825</dc:source>
 		<dc:source>https://catalog.hathitrust.org/Record/001112397</dc:source>
-		<meta property="se:word-count">33652</meta>
+		<meta property="se:word-count">33651</meta>
 		<meta property="se:reading-ease.flesch">76.93</meta>
 		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Pygmalion_(play)</meta>
 		<meta property="se:url.vcs.github">https://github.com/standardebooks/george-bernard-shaw_pygmalion</meta>

--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -90,6 +90,9 @@
 		<meta property="file-as" refines="#producer-2">Grigg, David</meta>
 		<meta property="se:url.homepage" refines="#producer-2">https://thegriggs.org/david/</meta>
 		<meta property="role" refines="#producer-2" scheme="marc:relators">pfr</meta>
+		<dc:contributor id="producer-3">Asher Smith</dc:contributor>
+		<meta property="file-as" refines="#producer-3">Smith, Asher</meta>
+		<meta property="role" refines="#producer-3" scheme="marc:relators">pfr</meta>
 	</metadata>
 	<manifest>
 		<item href="css/core.css" id="core.css" media-type="text/css"/>

--- a/src/epub/text/act-1.xhtml
+++ b/src/epub/text/act-1.xhtml
@@ -614,7 +614,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">The Flower Girl</td>
-						<td><i epub:type="z3998:stage-direction">With grandeur.</i> Never you mind, young man. I’m going home in a taxi. <i epub:type="z3998:stage-direction">She sails off to the cab. The driver puts his hand behind him and holds the door firmly shut against her. Quite understanding his mistrust, she shows him her handful of money.</i> Eightpence ain’t no object to me, Charlie. <i epub:type="z3998:stage-direction">He grins and opens the door.</i> Angel Court, Drury Lane, round the corner of Micklejohn’s oil shop. Let’s see how fast you can make her hop it. <i epub:type="z3998:stage-direction">She gets in and pulls the door to with a slam as the taxicab starts.</i></td>
+						<td><i epub:type="z3998:stage-direction">With grandeur.</i> Never you mind, young man. <em>I’m</em> going home in a taxi. <i epub:type="z3998:stage-direction">She sails off to the cab. The driver puts his hand behind him and holds the door firmly shut against her. Quite understanding his mistrust, she shows him her handful of money.</i> Eightpence ain’t no object to me, Charlie. <i epub:type="z3998:stage-direction">He grins and opens the door.</i> Angel Court, Drury Lane, round the corner of Micklejohn’s oil shop. Let’s see how fast you can make her hop it. <i epub:type="z3998:stage-direction">She gets in and pulls the door to with a slam as the taxicab starts.</i></td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Freddy</td>

--- a/src/epub/text/act-1.xhtml
+++ b/src/epub/text/act-1.xhtml
@@ -188,7 +188,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">The Daughter</td>
-						<td>Sixpence thrown away! Really, mamma, you might have spared Freddy that. <i epub:type="z3998:stage-direction">She retreats in disgust behind the pillar.</i></td>
+						<td>Sixpence thrown away! Really, mamma, you might have spared Freddy <em>that</em>. <i epub:type="z3998:stage-direction">She retreats in disgust behind the pillar.</i></td>
 					</tr>
 					<tr>
 						<td/>

--- a/src/epub/text/act-2.xhtml
+++ b/src/epub/text/act-2.xhtml
@@ -1171,7 +1171,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Doolittle</td>
-						<td>Tell her so, Governor: tell her so. <em>I</em>’m willing. It’s me that suffers by it. I’ve no hold on her. I got to be agreeable to her. I got to give her presents. I got to buy her clothes something sinful. I’m a slave to that woman, Governor, just because I’m not her lawful husband. And she knows it too. Catch her marrying me! Take my advice, Governor: marry Eliza while she’s young and don’t know no better. If you don’t you’ll be sorry for it after. If you do, she’ll be sorry for it after; but better you than her, because you’re a man, and she’s only a woman and don’t know how to be happy anyhow.</td>
+						<td>Tell her so, Governor: tell her so. <em>I’m</em> willing. It’s me that suffers by it. I’ve no hold on her. I got to be agreeable to her. I got to give her presents. I got to buy her clothes something sinful. I’m a slave to that woman, Governor, just because I’m not her lawful husband. And she knows it too. Catch her marrying me! Take my advice, Governor: marry Eliza while she’s young and don’t know no better. If you don’t you’ll be sorry for it after. If you do, <em>she’ll</em> be sorry for it after; but better you than her, because you’re a man, and she’s only a woman and don’t know how to be happy anyhow.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Higgins</td>

--- a/src/epub/text/act-2.xhtml
+++ b/src/epub/text/act-2.xhtml
@@ -107,7 +107,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">The Flower Girl</td>
-						<td>Oh, we are proud! He ain’t above giving lessons, not him: I heard him say so. Well, I ain’t come here to ask for any compliment; and if my money’s not good enough I can go elsewhere.</td>
+						<td>Oh, we <em>are</em> proud! He ain’t above giving lessons, not him: I heard him say so. Well, I ain’t come here to ask for any compliment; and if my money’s not good enough I can go elsewhere.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Higgins</td>
@@ -743,7 +743,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona"><abbr epub:type="z3998:name-title">Mrs.</abbr> Pearce</td>
-						<td><i epub:type="z3998:stage-direction">Not to be put off.</i>⁠—but there is a certain word I must ask you not to use. The girl has just used it herself because the bath was too hot. It begins with the same letter as bath. She knows no better: she learnt it at her mother’s knee. But she must not hear it from your lips.</td>
+						<td><i epub:type="z3998:stage-direction">Not to be put off.</i>⁠—but there is a certain word I must ask you not to use. The girl has just used it herself because the bath was too hot. It begins with the same letter as bath. <em>She</em> knows no better: she learnt it at her mother’s knee. But she must not hear it from your lips.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Higgins</td>
@@ -971,7 +971,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Pickering</td>
-						<td>Oh, <strong>please</strong>, Higgins: I’m west country myself. <i epub:type="z3998:stage-direction">To <b epub:type="z3998:persona">Doolittle</b>.</i> How did you know the girl was here if you didn’t send her?</td>
+						<td>Oh, <em>please</em>, Higgins: I’m west country myself. <i epub:type="z3998:stage-direction">To <b epub:type="z3998:persona">Doolittle</b>.</i> How did you know the girl was here if you didn’t send her?</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Doolittle</td>
@@ -1351,7 +1351,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Liza</td>
-						<td>Oh, I don’t mind; only it sounded so genteel. I should just like to take a taxi to the corner of Tottenham Court Road and get out there and tell it to wait for me, just to put the girls in their place a bit. I wouldn’t speak to them, you know.</td>
+						<td>Oh, I don’t mind; only it sounded so genteel. I <em>should</em> just like to take a taxi to the corner of Tottenham Court Road and get out there and tell it to wait for me, just to put the girls in their place a bit. I wouldn’t speak to them, you know.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Pickering</td>

--- a/src/epub/text/act-3.xhtml
+++ b/src/epub/text/act-3.xhtml
@@ -78,7 +78,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona"><abbr epub:type="z3998:name-title">Mrs.</abbr> Higgins</td>
-						<td>Does that mean that some girl has picked you up?</td>
+						<td>Does that mean that some girl has picked <em>you</em> up?</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Higgins</td>
@@ -500,7 +500,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Liza</td>
-						<td>Y-e-e-e-es, Lord love you! Why should she die of influenza? She come through diphtheria right enough the year before. I saw her with my own eyes. Fairly blue with it, she was. They all thought she was dead; but my father he kept ladling gin down her throat till she came to so sudden that she bit the bowl off the spoon.</td>
+						<td>Y-e-e-e-es, Lord love you! Why should <em>she</em> die of influenza? She come through diphtheria right enough the year before. I saw her with my own eyes. Fairly blue with it, she was. They all thought she was dead; but my father he kept ladling gin down her throat till she came to so sudden that she bit the bowl off the spoon.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona"><abbr epub:type="z3998:name-title">Mrs.</abbr> Eynsford Hill</td>
@@ -794,7 +794,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Higgins</td>
-						<td><abbr epub:type="z3998:name-title">Mrs.</abbr> Pearce? Oh, she’s jolly glad to get so much taken off her hands; for before Eliza came, she had to have to find things and remind me of my appointments. But she’s got some silly bee in her bonnet about Eliza. She keeps saying “You don’t think, sir”: doesn’t she, Pick?</td>
+						<td><abbr epub:type="z3998:name-title">Mrs.</abbr> Pearce? Oh, she’s jolly glad to get so much taken off her hands; for before Eliza came, <em>she</em> had to have to find things and remind me of my appointments. But she’s got some silly bee in her bonnet about Eliza. She keeps saying “You don’t <em>think</em>, sir”: doesn’t she, Pick?</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Pickering</td>

--- a/src/epub/text/act-4.xhtml
+++ b/src/epub/text/act-4.xhtml
@@ -172,9 +172,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Liza</td>
-						<td>
-							<i epub:type="z3998:stage-direction">Gives a suffocated scream of fury, and instinctively darts her nails at his face.</i> !!
-						</td>
+						<td><i epub:type="z3998:stage-direction">Gives a suffocated scream of fury, and instinctively darts her nails at his face.</i> !!</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Higgins</td>

--- a/src/epub/text/act-4.xhtml
+++ b/src/epub/text/act-4.xhtml
@@ -160,7 +160,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Higgins</td>
-						<td><strong>You</strong> won my bet! You! Presumptuous insect! <em>I</em> won it. What did you throw those slippers at me for?</td>
+						<td><em>You</em> won my bet! You! Presumptuous insect! <em>I</em> won it. What did you throw those slippers at me for?</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Liza</td>
@@ -272,7 +272,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Higgins</td>
-						<td><i epub:type="z3998:stage-direction">Enlightened, but not at all impressed.</i> Oh, that’s what’s worrying you, is it? <i epub:type="z3998:stage-direction">He thrusts his hands into his pockets, and walks about in his usual manner, rattling the contents of his pockets, as if condescending to a trivial subject out of pure kindness.</i> I shouldn’t bother about it if I were you. I should imagine you won’t have much difficulty in settling yourself, somewhere or other, though I hadn’t quite realized that you were going away. <i epub:type="z3998:stage-direction">She looks quickly at him: he does not look at her, but examines the dessert stand on the piano and decides that he will eat an apple.</i> You might marry, you know. <i epub:type="z3998:stage-direction">He bites a large piece out of the apple, and munches it noisily.</i> You see, Eliza, all men are not confirmed old bachelors like me and the Colonel. Most men are the marrying sort (poor devils!); and you’re not bad-looking; it’s quite a pleasure to look at you sometimes⁠—not now, of course, because you’re crying and looking as ugly as the very devil; but when you’re all right and quite yourself, you’re what I should call attractive. That is, to the people in the marrying line, you understand. You go to bed and have a good nice rest; and then get up and look at yourself in the glass; and you won’t feel so cheap.</td>
+						<td><i epub:type="z3998:stage-direction">Enlightened, but not at all impressed.</i> Oh, <em>that’s</em> what’s worrying you, is it? <i epub:type="z3998:stage-direction">He thrusts his hands into his pockets, and walks about in his usual manner, rattling the contents of his pockets, as if condescending to a trivial subject out of pure kindness.</i> I shouldn’t bother about it if I were you. I should imagine you won’t have much difficulty in settling yourself, somewhere or other, though I hadn’t quite realized that you were going away. <i epub:type="z3998:stage-direction">She looks quickly at him: he does not look at her, but examines the dessert stand on the piano and decides that he will eat an apple.</i> You might marry, you know. <i epub:type="z3998:stage-direction">He bites a large piece out of the apple, and munches it noisily.</i> You see, Eliza, all men are not confirmed old bachelors like me and the Colonel. Most men are the marrying sort (poor devils!); and you’re not bad-looking; it’s quite a pleasure to look at you sometimes⁠—not now, of course, because you’re crying and looking as ugly as the very devil; but when you’re all right and quite yourself, you’re what I should call attractive. That is, to the people in the marrying line, you understand. You go to bed and have a good nice rest; and then get up and look at yourself in the glass; and you won’t feel so cheap.</td>
 					</tr>
 					<tr>
 						<td/>

--- a/src/epub/text/act-4.xhtml
+++ b/src/epub/text/act-4.xhtml
@@ -173,7 +173,7 @@
 					<tr>
 						<td epub:type="z3998:persona">Liza</td>
 						<td>
-							<i epub:type="z3998:stage-direction">Gives a suffocated scream of fury, and instinctively darts her nails at his face.</i>
+							<i epub:type="z3998:stage-direction">Gives a suffocated scream of fury, and instinctively darts her nails at his face.</i> !!
 						</td>
 					</tr>
 					<tr>

--- a/src/epub/text/act-5.xhtml
+++ b/src/epub/text/act-5.xhtml
@@ -183,7 +183,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Doolittle</td>
-						<td><i epub:type="z3998:stage-direction">Indicating his own person.</i> See here! Do you see this? You done this.</td>
+						<td><i epub:type="z3998:stage-direction">Indicating his own person.</i> See here! Do you see this? <em>You</em> done this.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Higgins</td>
@@ -215,7 +215,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Doolittle</td>
-						<td>I shouldn’t mind if it had only happened to me: anything might happen to anybody and nobody to blame but Providence, as you might say. But this is something that you done to me: yes, you, Henry Higgins.</td>
+						<td>I shouldn’t mind if it had only <em>happened</em> to me: anything might happen to anybody and nobody to blame but Providence, as you might say. But this is something that <em>you</em> done to me: yes, <em>you</em>, Henry Higgins.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Higgins</td>
@@ -275,7 +275,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Doolittle</td>
-						<td>It ain’t the lecturing I mind. I’ll lecture them blue in the face, I will, and not turn a hair. It’s making a gentleman of me that I object to. Who asked him to make a gentleman of me? I was happy. I was free. I touched pretty nigh everybody for money when I wanted it, same as I touched you, Henry Higgins. Now I am worrited; tied neck and heels; and everybody touches me for money. It’s a fine thing for you, says my solicitor. Is it? says I. You mean it’s a good thing for you, I says. When I was a poor man and had a solicitor once when they found a pram in the dust cart, he got me off, and got shut of me and got me shut of him as quick as he could. Same with the doctors: used to shove me out of the hospital before I could hardly stand on my legs, and nothing to pay. Now they finds out that I’m not a healthy man and can’t live unless they looks after me twice a day. In the house I’m not let do a hand’s turn for myself: somebody else must do it and touch me for it. A year ago I hadn’t a relative in the world except two or three that wouldn’t speak to me. Now I’ve fifty, and not a decent week’s wages among the lot of them. I have to live for others and not for myself: that’s middle class morality. You talk of losing Eliza. Don’t you be anxious: I bet she’s on my doorstep by this: she that could support herself easy by selling flowers if I wasn’t respectable. And the next one to touch me will be you, Henry Higgins. I’ll have to learn to speak middle class language from you, instead of speaking proper English. That’s where you’ll come in; and I daresay that’s what you done it for.</td>
+						<td>It ain’t the lecturing I mind. I’ll lecture them blue in the face, I will, and not turn a hair. It’s making a gentleman of me that I object to. Who asked him to make a gentleman of me? I was happy. I was free. I touched pretty nigh everybody for money when I wanted it, same as I touched you, Henry Higgins. Now I am worrited; tied neck and heels; and everybody touches <em>me</em> for money. It’s a fine thing for you, says my solicitor. Is it? says I. You mean it’s a good thing for you, I says. When I was a poor man and had a solicitor once when they found a pram in the dust cart, he got me off, and got shut of me and got me shut of him as quick as he could. Same with the doctors: used to shove me out of the hospital before I could hardly stand on my legs, and nothing to pay. Now they finds out that I’m not a healthy man and can’t live unless they looks after me twice a day. In the house I’m not let do a hand’s turn for myself: somebody else must do it and touch me for it. A year ago I hadn’t a relative in the world except two or three that wouldn’t speak to me. Now I’ve fifty, and not a decent week’s wages among the lot of them. I have to live for others and not for myself: that’s middle class morality. <em>You</em> talk of losing Eliza. Don’t you be anxious: I bet she’s on my doorstep by this: she that could support herself easy by selling flowers if I wasn’t respectable. And the next one to touch me will be you, Henry Higgins. I’ll have to learn to speak middle class language from you, instead of speaking proper English. That’s where you’ll come in; and I daresay that’s what you done it for.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona"><abbr epub:type="z3998:name-title">Mrs.</abbr> Higgins</td>
@@ -599,7 +599,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Liza</td>
-						<td>Yes: things that showed you thought and felt about me as if I were something better than a scullery maid; though of course I know you would have been just the same to a scullery maid if she had been let in the drawing-room. You never took off your boots in the dining room when I was there.</td>
+						<td>Yes: things that showed you thought and felt about me as if I were something better than a scullery maid; though of course I know you would have been just the same to a scullery maid if she had been let in the drawing-room. <em>You</em> never took off your boots in the dining room when I was there.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Pickering</td>
@@ -969,7 +969,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Liza</td>
-						<td><i epub:type="z3998:stage-direction">Looking fiercely round at him.</i> I wouldn’t marry <strong>you</strong> if you asked me; and you’re nearer my age than what he is.</td>
+						<td><i epub:type="z3998:stage-direction">Looking fiercely round at him.</i> I wouldn’t marry <em>you</em> if you asked me; and you’re nearer my age than what he is.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Higgins</td>
@@ -1089,7 +1089,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Liza</td>
-						<td><i epub:type="z3998:stage-direction">Defiantly nonresistant.</i> Wring away. What do I care? I knew you’d strike me some day. <i epub:type="z3998:stage-direction">He lets her go, stamping with rage at having forgotten himself, and recoils so hastily that he stumbles back into his seat on the ottoman.</i> Aha! Now I know how to deal with you. What a fool I was not to think of it before! You can’t take away the knowledge you gave me. You said I had a finer ear than you. And I can be civil and kind to people, which is more than you can. Aha! That’s done you, Henry Higgins, it has. Now I don’t care that <i epub:type="z3998:stage-direction">Snapping her fingers</i> for your bullying and your big talk. I’ll advertise it in the papers that your duchess is only a flower girl that you taught, and that she’ll teach anybody to be a duchess just the same in six months for a thousand guineas. Oh, when I think of myself crawling under your feet and being trampled on and called names, when all the time I had only to lift up my finger to be as good as you, I could just kick myself.</td>
+						<td><i epub:type="z3998:stage-direction">Defiantly nonresistant.</i> Wring away. What do I care? I knew you’d strike me some day. <i epub:type="z3998:stage-direction">He lets her go, stamping with rage at having forgotten himself, and recoils so hastily that he stumbles back into his seat on the ottoman.</i> Aha! Now I know how to deal with you. What a fool I was not to think of it before! You can’t take away the knowledge you gave me. You said I had a finer ear than you. And I can be civil and kind to people, which is more than you can. Aha! That’s done you, Henry Higgins, it has. Now I don’t care <em>that</em> <i epub:type="z3998:stage-direction">Snapping her fingers</i> for your bullying and your big talk. I’ll advertise it in the papers that your duchess is only a flower girl that you taught, and that she’ll teach anybody to be a duchess just the same in six months for a thousand guineas. Oh, when I think of myself crawling under your feet and being trampled on and called names, when all the time I had only to lift up my finger to be as good as you, I could just kick myself.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">Higgins</td>

--- a/src/epub/text/act-5.xhtml
+++ b/src/epub/text/act-5.xhtml
@@ -21,7 +21,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">The Parlormaid</td>
-						<td><i epub:type="z3998:stage-direction">At the door.</i> <abbr epub:type="z3998:name-title">Mr.</abbr> Henry, ma’am, is downstairs with Colonel Pickering.</td>
+						<td><i epub:type="z3998:stage-direction">At the door.</i> <abbr epub:type="z3998:name-title">Mr.</abbr> Henry, mam, is downstairs with Colonel Pickering.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona"><abbr epub:type="z3998:name-title">Mrs.</abbr> Higgins</td>
@@ -29,7 +29,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">The Parlormaid</td>
-						<td>They’re using the telephone, ma’am. Telephoning to the police, I think.</td>
+						<td>They’re using the telephone, mam. Telephoning to the police, I think.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona"><abbr epub:type="z3998:name-title">Mrs.</abbr> Higgins</td>
@@ -37,7 +37,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">The Parlormaid</td>
-						<td><i epub:type="z3998:stage-direction">Coming further in and lowering her voice.</i> <abbr epub:type="z3998:name-title">Mr.</abbr> Henry’s in a state, ma’am. I thought I’d better tell you.</td>
+						<td><i epub:type="z3998:stage-direction">Coming further in and lowering her voice.</i> <abbr epub:type="z3998:name-title">Mr.</abbr> Henry’s in a state, mam. I thought I’d better tell you.</td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona"><abbr epub:type="z3998:name-title">Mrs.</abbr> Higgins</td>
@@ -45,7 +45,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">The Parlormaid</td>
-						<td>Yes, ma’am <i epub:type="z3998:stage-direction">Going.</i></td>
+						<td>Yes, mam <i epub:type="z3998:stage-direction">Going.</i></td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona"><abbr epub:type="z3998:name-title">Mrs.</abbr> Higgins</td>
@@ -53,7 +53,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">The Parlormaid</td>
-						<td>Yes, ma’am.</td>
+						<td>Yes, mam.</td>
 					</tr>
 					<tr>
 						<td/>
@@ -433,7 +433,7 @@
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona">The Parlormaid</td>
-						<td>Yes, ma’am. <i epub:type="z3998:stage-direction">She goes out.</i></td>
+						<td>Yes, mam. <i epub:type="z3998:stage-direction">She goes out.</i></td>
 					</tr>
 					<tr>
 						<td epub:type="z3998:persona"><abbr epub:type="z3998:name-title">Mrs.</abbr> Higgins</td>


### PR DESCRIPTION
- I've added in all the `<em>` incidences I can find, sometimes converting from `<strong>`
- I've made a couple [Editorial] changes where Shaw only italicises the "I" in "I'm" to italicise the whole word.
- Somehow this had an effect on the word count, so I've updated that.
- The issue of punctuation as dialogue turns up here but was missing in our edition, so I've restored that and added a lint-ignore file.
- I've changed the spelling of ma'am back to mam when spoken by the parlormaid, as this is a phonetic spelling only said by that one character.